### PR TITLE
Fix C.GoBytes parsed as *ast.ReturnStmt

### DIFF
--- a/pkg/nlreturn/nlreturn.go
+++ b/pkg/nlreturn/nlreturn.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"strings"
 
 	"golang.org/x/tools/go/analysis"
 )
@@ -49,6 +50,14 @@ func inspectBlock(pass *analysis.Pass, block []ast.Stmt) {
 				return
 			}
 
+			if !strings.HasSuffix(pass.Fset.Position(stmt.Pos()).Filename, ".go") {
+				return
+			}
+
+			if isFalsePositive(stmt) {
+				return
+			}
+
 			if line(pass, stmt.Pos())-line(pass, block[i-1].End()) <= 1 {
 				pass.Report(analysis.Diagnostic{
 					Pos:     stmt.Pos(),
@@ -83,4 +92,31 @@ func name(stmt ast.Stmt) string {
 
 func line(pass *analysis.Pass, pos token.Pos) int {
 	return pass.Fset.Position(pos).Line
+}
+
+func isFalsePositive(node ast.Node) bool {
+	r, ok := node.(*ast.ReturnStmt)
+	if !ok {
+		return false
+	}
+
+	if len(r.Results) != 1 {
+		return false
+	}
+
+	call, ok := r.Results[0].(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+
+	fun, ok := call.Fun.(*ast.Ident)
+	if !ok {
+		return false
+	}
+
+	if fun.Name == "_Cfunc_GoBytes" {
+		return true
+	}
+
+	return false
 }

--- a/testdata/src/p/p.go
+++ b/testdata/src/p/p.go
@@ -1,5 +1,10 @@
 package main
 
+import "C"
+import (
+	"unsafe"
+)
+
 func cha() {
 	ch := make(chan interface{})
 	ch1 := make(chan interface{})
@@ -157,4 +162,16 @@ func bugNoGoSmthHandling(string) {
 
 		return
 	}
+}
+
+func bugCgo() []byte {
+	ch := make(chan interface{})
+	if ch != nil {
+		return nil
+	}
+	return C.GoBytes(unsafe.Pointer(C.CString("")), C.int(1)) // want "return with no blank line before"
+}
+
+func bugCgo2() []byte {
+	return C.GoBytes(unsafe.Pointer(C.CString("")), C.int(1))
 }


### PR DESCRIPTION
`C.GoBytes()` is seen as an `*ast.ReturnStmt` so it must be excluded from
the linter. When returned, two return statements will be seen so it will
always report a false positive.

Closes #4 

---

I added tests to prove this behaviour but sadly this adds a dependency to CGO. To be honest I don't think it's an issue since it's only tests - the linter will continue to work without CGO. Since this new dependency also compiles files to the cache (which is passed as `pass.Fset`, I had to add a check that we only lint `.go` files. I've seen this issue with other linters as well, not sure how else this could be solved to only process `.go` files in the passed package.

Let me know if you wan't me to drop the tests, that way we will not depend on CGO and we won't need the new check of file extension, however we cannot assert that the bug is fixed.

Lastly, I only compare towards the known function right now (`_Cfunc_GoBytes`) but it would be easy to add more special cases if needed. By looking at the AST, I saw no other obvious solution other than actually checking the specific `*ast.Ident`.