### PR TITLE
fix: off-by-one error

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ func bar() int {
     return a
 }
 ```
+
+# Args
+
+* `-block-size n` size of the block (including return statement that is still "OK") so no return split required.

--- a/pkg/nlreturn/nlreturn.go
+++ b/pkg/nlreturn/nlreturn.go
@@ -50,11 +50,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 }
 
 func inspectBlock(pass *analysis.Pass, block []ast.Stmt) {
-
 	for i, stmt := range block {
 		switch stmt.(type) {
 		case *ast.BranchStmt, *ast.ReturnStmt:
-			if line(pass, stmt.Pos())-line(pass, block[0].Pos()) < blockSize {
+
+			if i == 0 || line(pass, stmt.Pos())-line(pass, block[0].Pos()) < blockSize {
 				return
 			}
 


### PR DESCRIPTION
Added in #7, found while integrating configuration on `golangci-lint` https://github.com/golangci/golangci-lint/pull/2237